### PR TITLE
Upgrade administrate to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,8 +79,6 @@ gem 'rspec_api_documentation', '~> 6.1'
 
 gem 'acts-as-taggable-on', '~> 11.0.0'
 
-gem 'administrate-field-acts_as_taggable'
-
 gem 'administrate-field-list', '~> 0.0.6'
 
 gem 'httparty', '~> 0.20.0'

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,12 @@ gem 'administrate'
 gem 'administrate-field-jsonb'
 gem 'trix-rails', require: 'trix'
 
+# administrate < 1.0 pulled these in transitively via sassc-rails; administrate 1.0
+# bundles its own assets and dropped that dependency, but the app's own asset
+# pipeline (app/assets/config/manifest.js) still relies on Sprockets/Sass directly.
+gem 'sprockets-rails'
+gem 'sassc-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]
@@ -67,6 +73,9 @@ group :test do
   # chromedriver binary itself (Selenium Manager) - no separate webdriver gem needed.
   gem 'capybara'
   gem 'selenium-webdriver'
+  # CDP support, needed for Selenium's driver.register(username:, password:) - used to
+  # authenticate admin system specs without embedding credentials in the visited URL.
+  gem 'selenium-devtools'
 end
 
 gem 'pundit', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,14 +78,11 @@ GEM
       zeitwerk (>= 2.4, < 3.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    administrate (0.20.1)
-      actionpack (>= 6.0, < 8.0)
-      actionview (>= 6.0, < 8.0)
-      activerecord (>= 6.0, < 8.0)
-      jquery-rails (~> 4.6.0)
+    administrate (1.0.0)
+      actionpack (>= 6.0, < 9.0)
+      actionview (>= 6.0, < 9.0)
+      activerecord (>= 6.0, < 9.0)
       kaminari (~> 1.2.2)
-      sassc-rails (~> 2.1)
-      selectize-rails (~> 0.6)
     administrate-field-active_storage (0.4.2)
       administrate (>= 0.2.2)
       rails (>= 7.0)
@@ -202,10 +199,6 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
-    jquery-rails (4.6.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     json (2.7.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -405,7 +398,8 @@ GEM
       activemodel (>= 6.1)
       hashie
     securerandom (0.3.1)
-    selectize-rails (0.12.6)
+    selenium-devtools (0.151.0)
+      selenium-webdriver (~> 4.2)
     selenium-webdriver (4.46.0)
       base64 (~> 0.2)
       logger (~> 1.4)
@@ -425,8 +419,9 @@ GEM
       fugit (~> 1.8, >= 1.11.1)
       globalid (>= 1.0.1)
       sidekiq (>= 6.5.0)
-    sprockets (4.2.1)
+    sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
+      logger
       rack (>= 2.2.4, < 4)
     sprockets-rails (3.5.2)
       actionpack (>= 6.1)
@@ -436,7 +431,7 @@ GEM
     strscan (3.1.0)
     systemu (2.6.5)
     thor (1.3.1)
-    tilt (2.4.0)
+    tilt (2.8.0)
     timeout (0.4.1)
     trix-rails (2.4.0)
       rails (> 4.1)
@@ -508,11 +503,14 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   rubocop-rspec_rails
+  sassc-rails
   searchkick
+  selenium-devtools
   selenium-webdriver
   shoulda-matchers
   sidekiq (>= 7.2.2, < 8)
   sidekiq-cron (~> 2.4.0)
+  sprockets-rails
   trix-rails
   tzinfo-data
   uuid (~> 2.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,11 +89,8 @@ GEM
     administrate-field-active_storage (0.4.2)
       administrate (>= 0.2.2)
       rails (>= 7.0)
-    administrate-field-acts_as_taggable (0.0.4)
-      acts-as-taggable-on (>= 6.0)
-      administrate (< 1.0.0)
-    administrate-field-jsonb (0.4.6)
-      administrate (< 1.0.0)
+    administrate-field-jsonb (0.4.8)
+      administrate (< 2.0)
       rails (>= 4.2)
     administrate-field-list (0.0.6)
       administrate
@@ -481,7 +478,6 @@ DEPENDENCIES
   addressable (~> 2.8)
   administrate
   administrate-field-active_storage (~> 0.4.1)
-  administrate-field-acts_as_taggable
   administrate-field-jsonb
   administrate-field-list (~> 0.0.6)
   aws-sdk-rails (~> 5.0)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -6,7 +6,6 @@
 //= link administrate-field-jsonb/application.js
 //= link acts_as_taggable_field.js
 //= link administrate-field-active_storage/application.css
-//= require selectize
 //= require trix
 // application.js
 // application.css

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -4,8 +4,7 @@
 //= link_tree ../../../vendor/javascript .js
 //= link administrate-field-jsonb/application.css
 //= link administrate-field-jsonb/application.js
-//= link administrate-field-taggable/application.js
-//= link administrate-field-taggable/application.css
+//= link acts_as_taggable_field.js
 //= link administrate-field-active_storage/application.css
 //= require selectize
 //= require trix

--- a/app/assets/javascripts/acts_as_taggable_field.js
+++ b/app/assets/javascripts/acts_as_taggable_field.js
@@ -1,0 +1,20 @@
+// Selectize init for ActsAsTaggableField's text input, ported from the
+// unmaintained administrate-field-acts_as_taggable gem's application.js.
+$(function() {
+  $(".field-unit--acts-as-taggable-field .field-unit__field > input").each(function(elem) {
+    var $this = $(this);
+    var opts = $this.data('tag-options');
+
+    $this.selectize({
+      delimiter: ", ",
+      persist: false,
+      options: opts,
+      create: function(input) {
+        return {
+          value: input,
+          text: input
+        };
+      }
+    });
+  })
+});

--- a/app/assets/stylesheets/acts_as_taggable_field.css
+++ b/app/assets/stylesheets/acts_as_taggable_field.css
@@ -1,0 +1,9 @@
+.taggable_field .tag {
+  text-align: center;
+  font-size: 0.85em;
+  margin: 0 3px 3px 0;
+  padding: 2px 6px;
+  background: #f2f2f2;
+  color: #303030;
+  border: 0 solid #d0d0d0;
+}

--- a/app/dashboards/mention_dashboard.rb
+++ b/app/dashboards/mention_dashboard.rb
@@ -18,7 +18,7 @@ class MentionDashboard < Administrate::BaseDashboard
     id: Field::Number,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
-    tags: Field::ActsAsTaggable
+    tags: ActsAsTaggableField
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/fields/acts_as_taggable_field.rb
+++ b/app/fields/acts_as_taggable_field.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'administrate/field/text'
+require 'administrate/engine'
+
+# In-house replacement for the unmaintained administrate-field-acts_as_taggable gem
+# (last released 2021, hard-pins `administrate < 1.0.0`). Behavior is ported as-is
+# from that gem's lib/administrate/field/acts_as_taggable.rb.
+class ActsAsTaggableField < Administrate::Field::Text
+  class Engine < ::Rails::Engine
+    if defined?(Administrate::Engine)
+      Administrate::Engine.add_javascript 'acts_as_taggable_field'
+      Administrate::Engine.add_stylesheet 'acts_as_taggable_field'
+    end
+  end
+
+  def context
+    options.fetch(:context, @attribute)
+  end
+
+  # acts_as_taggable_on exposes a `<context.singularize>_list` virtual attribute
+  # (e.g. `tag_list` for the `:tags` context) for reading/writing a comma-delimited
+  # tag string - this field operates on that attribute rather than the raw `tags`
+  # association.
+  def attribute
+    "#{super.to_s.singularize}_list"
+  end
+
+  def self.permitted_attribute(attr, **_opts)
+    "#{attr.to_s.singularize}_list"
+  end
+
+  def tags
+    data
+  end
+
+  def name
+    context.to_s
+  end
+
+  def delimited
+    tags.join(', ').to_s
+  end
+
+  def truncate
+    delimited[0...truncation_length]
+  end
+
+  def tag_options
+    return [] unless defined?(ActsAsTaggableOn::Tag)
+
+    ActsAsTaggableOn::Tag.for_context(context).order(:name).map do |t|
+      { text: t.name, value: t.name }
+    end
+  end
+end

--- a/app/views/admin/media/show.html.erb
+++ b/app/views/admin/media/show.html.erb
@@ -25,12 +25,13 @@ as well as a link to its edit page.
       t("administrate.actions.edit_resource", name: page.page_title),
       [:edit, namespace, page.resource],
       class: "button",
-    ) if accessible_action?(:edit) && accessible_action?(:edit, page.resource) %>
+    ) if accessible_action?(page.resource, :edit) %>
   </div>
 </header>
 <section class="main-content__body">
   <figure>
-    <img src="<%= page.resource.url %>" alt="<%= page.resource.alt_text %>" />
+    <% media_url = page.resource.image.attached? ? url_for(page.resource.image) : page.resource.link %>
+    <img src="<%= media_url %>" alt="<%= page.resource.alt_text %>" />
     <figcaption><%= page.resource.caption %></figcaption>
     <dl>
       <% page.attributes.each do |title, attributes| %>

--- a/app/views/admin/mentions/_form.html.erb
+++ b/app/views/admin/mentions/_form.html.erb
@@ -33,10 +33,12 @@ and renders all form fields for a resource's editable attributes.
     </div>
   <% end %>
 
-  <% page.attributes(controller.action_name).each do |attribute| -%>
-    <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
-      <%= render_field attribute, f: f %>
-    </div>
+  <% page.attributes(controller.action_name).each do |title, attributes| -%>
+    <% attributes.each do |attribute| %>
+      <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+        <%= render_field attribute, f: f %>
+      </div>
+    <% end -%>
   <% end -%>
 
   <div class="form-actions">

--- a/app/views/admin/mentions/edit.html.erb
+++ b/app/views/admin/mentions/edit.html.erb
@@ -34,7 +34,7 @@ It displays a header, and renders the `_form` partial to do the heavy lifting.
       t("administrate.actions.show_resource", name: page.page_title),
       [namespace, page.resource],
       class: "button",
-    ) if accessible_action?(:show) && accessible_action?(:show, page.resource) %>
+    ) if accessible_action?(page.resource, :show) %>
   </div>
 </header>
 <section class="main-content__body">

--- a/app/views/fields/acts_as_taggable_field/_form.html.erb
+++ b/app/views/fields/acts_as_taggable_field/_form.html.erb
@@ -1,0 +1,6 @@
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.text_field field.attribute, value: field.delimited, data: { tag_options: field.tag_options } %>
+</div>

--- a/app/views/fields/acts_as_taggable_field/_index.html.erb
+++ b/app/views/fields/acts_as_taggable_field/_index.html.erb
@@ -1,0 +1,1 @@
+<%= field.truncate %>

--- a/app/views/fields/acts_as_taggable_field/_show.html.erb
+++ b/app/views/fields/acts_as_taggable_field/_show.html.erb
@@ -1,0 +1,5 @@
+<div class="taggable_field">
+  <% field.tags.each do |tag| %>
+    <span class="tag"><span class="tag__name"><%= tag.name -%></span></span>
+  <% end %>
+</div>

--- a/spec/fields/acts_as_taggable_field_spec.rb
+++ b/spec/fields/acts_as_taggable_field_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'administrate/field/text'
+
+RSpec.describe ActsAsTaggableField do
+  describe '#attribute' do
+    it 'singularizes the underlying attribute and appends _list' do
+      field = described_class.new(:tags, [], nil)
+      expect(field.attribute).to eq('tag_list')
+    end
+  end
+
+  describe '.permitted_attribute' do
+    it 'singularizes the attribute and appends _list' do
+      expect(described_class.permitted_attribute(:tags)).to eq('tag_list')
+    end
+  end
+
+  describe '#tags' do
+    it 'returns the raw data' do
+      field = described_class.new(:tags, %w[a b], nil)
+      expect(field.tags).to eq(%w[a b])
+    end
+  end
+
+  describe '#delimited' do
+    it 'joins tag names with a comma and space' do
+      mention = create(:mention, tag_list: 'foo, bar')
+      field = described_class.new(:tags, mention.tags, nil)
+
+      expect(field.delimited).to eq('foo, bar')
+    end
+
+    it 'returns an empty string when there are no tags' do
+      field = described_class.new(:tags, [], nil)
+      expect(field.delimited).to eq('')
+    end
+  end
+
+  describe '#truncate' do
+    it 'truncates the delimited tag list to the default length' do
+      mention = create(:mention, tag_list: 'a' * 60)
+      field = described_class.new(:tags, mention.tags, nil)
+
+      expect(field.truncate.length).to eq(50)
+    end
+  end
+
+  describe '#tag_options' do
+    it 'lists tags used in the tags context, sorted by name' do
+      create(:mention, tag_list: 'zebra, apple')
+      field = described_class.new(:tags, [], nil)
+
+      expect(field.tag_options).to eq(
+        [{ text: 'apple', value: 'apple' }, { text: 'zebra', value: 'zebra' }]
+      )
+    end
+  end
+end

--- a/spec/requests/admin/about_pages_spec.rb
+++ b/spec/requests/admin/about_pages_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe 'Admin::AboutPages' do
       expect(response.body).to include(%(href="#{new_admin_about_page_path}"))
     end
 
-    it 'still renders the "destroy" link on the show page' do
+    it 'still renders the "destroy" button on the show page' do
       about_page = create(:about_page)
       get admin_about_page_path(about_page), headers: admin_auth_headers
-      expect(response.body).to include(%(href="#{admin_about_page_path(about_page)}"))
+      expect(response.body).to include(%(action="#{admin_about_page_path(about_page)}"))
         .and include('button--danger')
     end
   end

--- a/spec/requests/admin/media_spec.rb
+++ b/spec/requests/admin/media_spec.rb
@@ -18,13 +18,6 @@ RSpec.describe 'Admin::Media' do
 
   describe 'GET show' do
     it 'renders successfully when authenticated' do
-      pending(
-        'known bug: admin/media/show.html.erb:28 calls accessible_action?(:edit) with one ' \
-        'argument before the correct two-argument call - Administrate::ApplicationHelper#' \
-        'accessible_action? requires (target, action_name), so this raises ArgumentError ' \
-        "before the &&'d correct call, or page.resource.url (line 33, Medium has no #url " \
-        'method), is ever reached'
-      )
       medium = create(:medium)
       get admin_medium_path(medium), headers: admin_auth_headers
       expect(response).to have_http_status(:ok)

--- a/spec/requests/admin/mentions_spec.rb
+++ b/spec/requests/admin/mentions_spec.rb
@@ -26,12 +26,6 @@ RSpec.describe 'Admin::Mentions' do
 
   describe 'GET new' do
     it 'renders successfully when authenticated' do
-      pending(
-        'known bug: admin/mentions/_form.html.erb:36 iterates page.attributes(...) as a ' \
-        'flat list of fields, but it actually yields [title, attributes] pairs (see ' \
-        'admin/letters/_form.html.erb for the correct nested form), so `attribute.html_class` ' \
-        'raises NoMethodError on the Array'
-      )
       get new_admin_mention_path, headers: admin_auth_headers
       expect(response).to have_http_status(:ok)
     end
@@ -39,12 +33,6 @@ RSpec.describe 'Admin::Mentions' do
 
   describe 'GET edit' do
     it 'renders successfully when authenticated' do
-      pending(
-        'known bug: admin/mentions/edit.html.erb:37 calls ' \
-        'accessible_action?(:show) with one argument before the correct two-argument call - ' \
-        'Administrate::ApplicationHelper#accessible_action? requires (target, action_name), so ' \
-        'this raises ArgumentError before the &&\'d correct call is ever reached'
-      )
       mention = create(:mention)
       get edit_admin_mention_path(mention), headers: admin_auth_headers
       expect(response).to have_http_status(:ok)

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -24,5 +24,16 @@ RSpec.configure do |config|
 
   config.before(:each, :js, type: :system) do
     driven_by Capybara.javascript_driver
+
+    # Admin::ApplicationController gates every admin route behind HTTP Basic Auth, and
+    # this app has no session-based login to drive instead. Visiting with credentials
+    # embedded in the URL (http://user:pass@host/path) used to work, but Administrate
+    # 1.0 bundles Turbo, which calls history.replaceState on every page load - Chrome
+    # rejects replaceState targets that carry userinfo, and since Administrate's JS is
+    # one bundled IIFE, that uncaught exception aborts everything after it, including
+    # selectize's own setup. Real admin users never hit this (their location.href never
+    # carries credentials - Chrome only uses them for the auth handshake). Registering
+    # credentials via CDP instead keeps the visited URL clean and sidesteps it entirely.
+    Capybara.current_session.driver.browser.register(username: 'test', password: 'test')
   end
 end

--- a/spec/system/admin/letters_spec.rb
+++ b/spec/system/admin/letters_spec.rb
@@ -9,11 +9,6 @@ require 'rails_helper'
 # break (jquery-ujs -> Turbo/Stimulus, changed asset bundling in 1.0) - and the only
 # way to actually verify it is a real browser, since no request spec executes JS.
 RSpec.describe 'Admin::Letters entity picker', :js do
-  def visit_with_basic_auth(path)
-    server = Capybara.current_session.server
-    visit "http://test:test@#{server.host}:#{server.port}#{path}"
-  end
-
   def selectize
     "jQuery('.field-unit--has-many-through-field select')[0].selectize"
   end
@@ -21,7 +16,7 @@ RSpec.describe 'Admin::Letters entity picker', :js do
   it 'initializes jQuery and the selectize widget on the entities field' do
     letter = create(:letter)
 
-    visit_with_basic_auth(edit_admin_letter_path(letter))
+    visit edit_admin_letter_path(letter)
 
     expect(page.execute_script('return window.jQuery !== undefined')).to be true
     expect(page).to have_css('.selectize-control')
@@ -33,7 +28,7 @@ RSpec.describe 'Admin::Letters entity picker', :js do
     entity = create(:person_entity, label: 'Zzz System Spec Findable Entity')
     Entity.reindex
 
-    visit_with_basic_auth(edit_admin_letter_path(letter))
+    visit edit_admin_letter_path(letter)
     expect(page).to have_css('.selectize-control')
 
     page.execute_script("#{selectize}.addItem('#{entity.id}')")
@@ -49,7 +44,7 @@ RSpec.describe 'Admin::Letters entity picker', :js do
     letter.save!
     Entity.reindex
 
-    visit_with_basic_auth(edit_admin_letter_path(letter))
+    visit edit_admin_letter_path(letter)
     expect(page).to have_css(".item[data-value='#{entity.id}']")
 
     find(".item[data-value='#{entity.id}']").click
@@ -68,7 +63,7 @@ RSpec.describe 'Admin::Letters entity picker', :js do
     letter.save!
     Entity.reindex
 
-    visit_with_basic_auth(edit_admin_letter_path(letter))
+    visit edit_admin_letter_path(letter)
     expect(page).to have_css(".item[data-value='#{entity.id}']")
 
     find(".item[data-value='#{entity.id}']").click


### PR DESCRIPTION
## Summary
- Bumps `administrate` 0.20.1 → 1.0.0, now that the prior blockers (unmaintained tag field gem, `administrate-field-jsonb`'s version pin, two unrelated view bugs) are cleared
- Restores `sprockets-rails`/`sassc-rails` as direct dependencies - administrate 1.0 bundles its own precompiled assets and dropped them transitively, but this app's own asset pipeline (`app/assets/config/manifest.js`) and `administrate-field-jsonb`'s Sass-based stylesheet chain both need them directly
- Drops the now-dead `//= require selectize` manifest line (1.0 bundles its own copy of selectize inside its single built JS file)
- Fixes the admin system-test harness: it authenticated by embedding credentials in the visited URL (no session-based admin login exists), which broke once Turbo (newly bundled in 1.0) started calling `history.replaceState` on every page load - Chrome rejects `replaceState` targets carrying userinfo, and since Administrate's JS is one bundled IIFE, that uncaught exception aborted everything downstream, including selectize's own setup. Real admin users never hit this (their `location.href` never carries credentials). Switched to Selenium's CDP-based `driver.register(username:, password:)` instead.
- Updates one spec assertion for a real template change: the About Pages "Destroy" control is now a Turbo `<form>`+`<button>` instead of a UJS `<a href data-method="delete">` link (the `accessible_action?` bug it documents is unchanged/out of scope)

## Test plan
- [x] Full suite: 322 examples, 0 failures
- [x] System spec exercising the letters entity picker's jQuery/selectize behavior in real headless Chrome
- [x] Manually verified in a real browser - no console errors, jQuery/selectize widgets work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
